### PR TITLE
README: add warning about modifying the dbus conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ This code is a [Signal K Node Server](https://github.com/SignalK/signalk-server-
 reads data from a Victron GX-device, such as the
 [Cerbo GX](https://www.victronenergy.com/panel-systems-remote-monitoring/cerbo-gx) into signalk-server.
 
-Besides using those commercially available devices, it is also possible to run the
-[Venus OS](https://github.com/victronenergy/venus/wiki) on a
+Besides using the Cerbo GX, or any of the other commercially available GX devices, it is also
+possible to run [Venus OS](https://github.com/victronenergy/venus/wiki) on a
 [RaspberryPi2 or 3](https://github.com/victronenergy/venus/wiki/raspberrypi-install-venus-image),
 for example.
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # venus-signalk
 
 This code is a [Signal K Node Server](https://github.com/SignalK/signalk-server-node) plugin. It
-reads Victron data from a Venus-device, such as the
-[Color Control GX](https://www.victronenergy.com/panel-systems-remote-monitoring/color-control) or the
-[Venus GX](https://www.victronenergy.com/panel-systems-remote-monitoring/venus-gx) into Signal K.
+reads data from a Victron GX-device, such as the
+[Cerbo GX](https://www.victronenergy.com/panel-systems-remote-monitoring/cerbo-gx) into signalk-server.
 
 Besides using those commercially available devices, it is also possible to run the
 [Venus OS](https://github.com/victronenergy/venus/wiki) on a
@@ -18,28 +17,28 @@ Lynx Shunt VE.Can, as well as various integrated Lithium battery systems.
 - Tank senders: the resistive inputs on the Venus GX, as well as a tank sender connected to Venus
 over N2K
 
-Instead of taking data from a Venus device over TCP, which is what this plugin is for when you install
-it, it is also possible to run Signal K server on the Venus device itself. Possibly reducing one less
-box from the boat. More information here:
-https://github.com/SignalK/signalk-server-node/issues/517
+Know that there is also a version of Venus OS with signalk-server, and this plug-in pre-installed.
+In which case you don't need to self install or configure this plugin. See
+[Venus OS large](https://www.victronenergy.com/live/venus-os:large).
 
 ## Support
 Use the #victron channel on the [Signal K Slack](http://slack-invite.signalk.org/).
 
 ## Plugin installation & configuration
-Installing is simple: the plugin is available in the signalk app store. Simply click to
+Installing is simple, though do read and heed the warning below (!). The plugin is available in the signalk app store. Simply click to
 install.
 
 Then there are two settings. The first is how to connect to the Venus communication bus,
 called D-Bus. Choose between these two:
 
 - A. Connect to localhost
-- B. Connect to a Venus device over tcp
+- B. Connect to a GX-device over tcp
 
-Use option A when signalk-server is installed on the Venus itself. 
+Use option A when signalk-server is installed on the GX-device itself. 
 
-Use option B in case that signalk is one device, for example a raspberrypi running Raspbian, which needs to connect
-to for example a Venus GX or Color Control GX elsewhere on the network.
+Use option B in case signalk-server is a separate device, for example a raspberrypi running
+Raspbian, in which case the plugin needs to connect to the GX-device
+on the ethernet/wifi network.
 
 When using option B enter in the ipaddress and port of the Venus device in the plugin configuration.
 
@@ -50,13 +49,31 @@ to tcp. To make it do so, add these three lines exactly as they are to `/etc/dbu
       <listen>tcp:host=0.0.0.0,port=78</listen>
       <auth>ANONYMOUS</auth>
       <allow_anonymous/>
-    
-Reboot afterwards. And also remember that any update of the Venus device will override these
-(and any other) changes to the rootfs. Perhaps someday this can be added to Venus as a real
-setting instead of a hack. __Make sure to only do this on a trusted network.__
+
+Now double check and extremely carefully make sure no mistake is made in editing that dbus config file.
+
+WARNING: a typo or other error in there will brick the GX-device. And requires a special serial console
+cable or other procedure to recover it. And -obviously- all these changes are on your own
+risk and not covered by (Victron) warranty nor (Victron) support.
+
+Reboot afterwards. And also remember that any update of the GX-device will override these
+(and any other) changes to the rootfs.
+
+__Lastly: make sure to only open D-Bus on TCP on a trusted network, its not secure at all.__
 
 To make above change, you'll need
 [root access to the Venus device](https://www.victronenergy.com/live/ccgx:root_access).
+
+## Recovering a bricked GX-device
+
+In case you did make a mistake in the config file, and now your GX is in an endless reboot
+loop; here is what to do.
+
+For the CCGX I don't know how to recover it. Try checking
+[this thread](https://community.victronenergy.com/questions/78081/recovering-a-ccgx.html).
+
+For all other models, best is to get a serial console cable. See the Venus OS root access
+document for how to connect it.
 
 ## Test harness
 
@@ -64,10 +81,8 @@ To see data, without having actual Victron or other Venus compatible hardware se
 get and run below explained Dummy data script. Or, clone
 [dbus-recorder](https://github.com/victronenergy/dbus-recorder) and run play.sh.
 
-Note that using the test harness will cause for some errors during init, as it
-doesn't support doing a GetValue on the root item (/). See
-https://github.com/mpvader/venus-signalk/issues/8 for details. For testing, there
-errors are harmless.
+Note that using the test harness could cause for some errors during init, as it
+doesn't support doing a GetValue on the root item (/).
 
 ## How to develop this plugin outside of Signal K
 


### PR DESCRIPTION
Triggerd by this: https://community.victronenergy.com/questions/78081/recovering-a-ccgx.html

By the way. Its not very likely that we’ll look into making a config option for enabling tcp in the dbus config.

there is some issue with that; I dont remember what though; but stability most likely.