### PR TITLE
Allow mapping dcsource names

### DIFF
--- a/index.js
+++ b/index.js
@@ -115,12 +115,14 @@ module.exports = function (app) {
               type: {
                 enum: [
                   'com.victronenergy.battery',
+                  'com.victronenergy.dcsource',
                   'com.victronenergy.tank',
                   'com.victronenergy.solarcharger',
                   'com.victronenergy.vebus'
                 ],
                 enumNames: [
                   'Battery',
+                  'DC Source',
                   'Tank',
                   'Solar Charger',
                   'VE.Bus'


### PR DESCRIPTION
dcsource isn't recognised in the Signalk Schema, but we may as well still have pretty names.