### PR TITLE
FIX: handle virtual devices injected by Signal K plugins in D-Bus service initialization

### DIFF
--- a/dbus-listener.js
+++ b/dbus-listener.js
@@ -73,7 +73,7 @@ module.exports = function (app, messageCallback, address, plugin, pollInterval) 
           member: 'GetValue'
         },
         function (err, res) {
-          if (!err && res[1][0] === 'signalk-to-venus') {
+          if (!err && res[1][0] === 'signalk-virtual-device') {
             app.debug(`Ignoring virtual device ${name} created by Signal K`)
             delete services[owner]
             return


### PR DESCRIPTION
**Prevent data recursion from SignalK-to-Venus virtual devices**
I am working on a plugin "SignalK-to-Venus" to emulate battery monitors, temperature/humidity sensors, tank level sensors and switches by injecting battery data from Signal K into Venus OS (Victron D-Bus) as virtual devices. The "Signal K Venus" plugin would send the data of the emulated device back to Signal K, causing a recursion.

SignalK-to-Venus marks the injected devices by `this._export('/Mgmt/ProcessName', 'Process Name', 'signalk-to-venus', 's');`

This change adds filtering logic in the dbus-listener to detect and ignore virtual devices created by the SignalK-to-Venus plugin. When initializing D-Bus services, the code now checks for the `/Mgmt/ProcessName` property and skips any services that have this property set to `'signalk-to-venus'`, preventing the data loop between the two plugins.

**Changes:**

- Added ProcessName check in `initService()` function before device initialization
- Virtual devices are detected and excluded from the services list
- Debug logging added to track ignored virtual devices

This ensures that data injected into Venus OS by SignalK-to-Venus doesn't get sent back to Signal K, preventing infinite data loops while maintaining compatibility with genuine Victron devices.