### PR TITLE
feat: map Victron /Soh to electrical.batteries.{id}.capacity.stateOfHealth

### DIFF
--- a/src/mappings.ts
+++ b/src/mappings.ts
@@ -202,6 +202,13 @@ export const getMappings = (
       conversion: percentToRatio,
       units: 'ratio'
     },
+    '/Soh': {
+      path: (m) => {
+        return makePath(m, `${m.instanceName}.capacity.stateOfHealth`)
+      },
+      conversion: percentToRatio,
+      units: 'ratio'
+    },
     '/TimeToGo': {
       path: (m) =>
         `electrical.batteries.${m.instanceName}.capacity.timeRemaining`,


### PR DESCRIPTION
## Summary

Adds a `/Soh` mapping in `src/mappings.ts` so that Victron battery state-of-health (published as 0–100% on `com.victronenergy.battery` by BMS-equipped batteries — Pylontech, BYD, Freedom Won, BMZ, Lynx Smart BMS, BMV-712 with SOH, etc.) is surfaced on the matching Signal K path:

`electrical.batteries.{id}.capacity.stateOfHealth` (ratio, 1 = 100%)

The mapping mirrors the existing `/Soc` block and reuses `percentToRatio`. Devices that don't publish `/Soh` are unaffected — absence is normal for plain BMV/SmartShunt without an external BMS, and the mapping is harmless on those devices.

Not touched in this PR: the aggregated `com.victronenergy.system` `/Dc/Battery/Soh` value. Holding off on that to avoid duplicate sources for the same logical value until the per-battery path is confirmed in the field.

## Tested

- Built (`npm run build`), lint clean.
- Linked into a local Signal K server and verified the path appears on a BMS-equipped battery.