### PR TITLE
Add configurable custom Venus mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ Each custom mapping can define:
 
 - `venusPath` for the Venus path to match
 - `venusPathIsRegex` to interpret `venusPath` as a regex for advanced matching
-- `dbusService` to restrict which D-Bus service the mapping applies to
-- `dbusServiceMatchMode` to interpret `dbusService` as `none`, `prefix`, or `exact`
+- `dbusService` to restrict which D-Bus service the mapping applies to. Leave blank for no restriction.
+- `dbusServiceMatchMode` to interpret `dbusService` as `prefix` or `exact`
 - `signalkPath` as the target Signal K path template
 - `units` for Signal K metadata
 - `conversion` for a small set of built-in value conversions

--- a/README.md
+++ b/README.md
@@ -39,3 +39,48 @@ When using option B or C go enter the hostname or ipaddress of the Venus device 
 Also ensure that MQTT is turned on in the GX-devices Services Settings.
 
 Option D is mostly usefull for developer testing/debugging with other peoples systems, but could also be used if running signalk in a different location or network that the GC device
+
+## Custom mappings
+
+The plugin supports read-only `customMappings` in plugin configuration. This allows extra Venus MQTT/DBus values to be mapped into Signal K without patching the built-in mapping table.
+
+Each custom mapping can define:
+
+- `venusPath` for the Venus path to match
+- `venusPathIsRegex` to interpret `venusPath` as a regex for advanced matching
+- `dbusService` to restrict which D-Bus service the mapping applies to
+- `dbusServiceMatchMode` to interpret `dbusService` as `none`, `prefix`, or `exact`
+- `signalkPath` as the target Signal K path template
+- `units` for Signal K metadata
+- `conversion` for a small set of built-in value conversions
+
+Supported `signalkPath` template tokens:
+
+- `${instanceName}`
+- `${venusName}`
+- `${senderName}`
+
+Example: DVCC system max charge current
+
+```json
+{
+  "venusPath": "/Settings/SystemSetup/MaxChargeCurrent",
+  "signalkPath": "electrical.${venusName}.maxChargeCurrent",
+  "units": "A"
+}
+```
+
+Example: VE.Bus max charge current for all MultiPlus instances
+
+```json
+{
+  "venusPath": "^/Dc/0/MaxChargeCurrent$",
+  "venusPathIsRegex": true,
+  "dbusService": "com.victronenergy.vebus",
+  "dbusServiceMatchMode": "prefix",
+  "signalkPath": "electrical.chargers.${instanceName}.maxChargeCurrent",
+  "units": "A"
+}
+```
+
+This is intended for read-only extension of the data model, for example when Node-RED on a Cerbo GX publishes custom values into the Venus MQTT tree and you want them to appear in Signal K.

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ Each custom mapping can define:
 
 - `venusPath` for the Venus path to match
 - `venusPathIsRegex` to interpret `venusPath` as a regex for advanced matching
-- `dbusService` to restrict which D-Bus service the mapping applies to. Leave blank for no restriction.
-- `dbusServiceMatchMode` to interpret `dbusService` as `prefix` or `exact`
+- `senderFilter` to restrict which D-Bus sender the mapping applies to. Leave blank for no restriction.
+- `senderMatchMode` to interpret `senderFilter` as `prefix` or `exact`
 - `signalkPath` as the target Signal K path template
 - `units` for Signal K metadata
 - `conversion` for a small set of built-in value conversions
@@ -76,8 +76,8 @@ Example: VE.Bus max charge current for all MultiPlus instances
 {
   "venusPath": "^/Dc/0/MaxChargeCurrent$",
   "venusPathIsRegex": true,
-  "dbusService": "com.victronenergy.vebus",
-  "dbusServiceMatchMode": "prefix",
+  "senderFilter": "com.victronenergy.vebus",
+  "senderMatchMode": "prefix",
   "signalkPath": "electrical.chargers.${instanceName}.maxChargeCurrent",
   "units": "A"
 }

--- a/README.md
+++ b/README.md
@@ -42,45 +42,113 @@ Option D is mostly usefull for developer testing/debugging with other peoples sy
 
 ## Custom mappings
 
-The plugin supports read-only `customMappings` in plugin configuration. This allows extra Venus MQTT/DBus values to be mapped into Signal K without patching the built-in mapping table.
+Custom Mappings let you bring extra Venus MQTT values into Signal K without changing the plugin source code. This is intended for read-only mappings, for example when Node-RED on a Cerbo GX publishes custom values into the Venus MQTT tree and you want them to appear in Signal K.
 
-Each custom mapping can define:
+You configure these in the plugin settings under `Custom Mappings`.
 
-- `venusPath` for the Venus path to match
-- `venusPathIsRegex` to interpret `venusPath` as a regex for advanced matching
-- `senderFilter` to restrict which D-Bus sender the mapping applies to. Leave blank for no restriction.
-- `senderMatchMode` to interpret `senderFilter` as `prefix` or `exact`
-- `signalkPath` as the target Signal K path template
-- `units` for Signal K metadata
-- `conversion` for a small set of built-in value conversions
+For each custom mapping, the fields are:
 
-Supported `signalkPath` template tokens:
+- `Venus Path`
+  Enter the Venus path part that appears after the device section of the MQTT topic.
+- `Interpret Venus Path As Regex`
+  Leave this off for a normal exact match. Turn it on only when you want one mapping to match multiple similar Venus paths.
+- `D-Bus Sender Filter`
+  Optional. Use this when the same Venus path may appear under multiple devices and you only want one class of device. Leave blank for no restriction.
+- `D-Bus Sender Match Mode`
+  If you filled in `D-Bus Sender Filter`, choose whether it should be treated as a `Prefix` or `Exact` match.
+- `Signal K Path`
+  The Signal K path to write to.
+- `Units`
+  Optional Signal K units metadata.
+- `Conversion`
+  Optional value conversion.
+
+The `Signal K Path` field supports these placeholders:
 
 - `${instanceName}`
 - `${venusName}`
 - `${senderName}`
 
-Example: DVCC system max charge current
+### How to choose the Venus Path
 
-```json
-{
-  "venusPath": "/Settings/SystemSetup/MaxChargeCurrent",
-  "signalkPath": "electrical.${venusName}.maxChargeCurrent",
-  "units": "A"
-}
-```
+If the MQTT topic is:
 
-Example: VE.Bus max charge current for all MultiPlus instances
+`N/<portalId>/settings/0/Settings/SystemSetup/MaxChargeCurrent`
 
-```json
-{
-  "venusPath": "^/Dc/0/MaxChargeCurrent$",
-  "venusPathIsRegex": true,
-  "senderFilter": "com.victronenergy.vebus",
-  "senderMatchMode": "prefix",
-  "signalkPath": "electrical.chargers.${instanceName}.maxChargeCurrent",
-  "units": "A"
-}
-```
+then the `Venus Path` value is:
 
-This is intended for read-only extension of the data model, for example when Node-RED on a Cerbo GX publishes custom values into the Venus MQTT tree and you want them to appear in Signal K.
+`/Settings/SystemSetup/MaxChargeCurrent`
+
+If the MQTT topic is:
+
+`N/<portalId>/vebus/288/Dc/0/MaxChargeCurrent`
+
+then the `Venus Path` value is:
+
+`/Dc/0/MaxChargeCurrent`
+
+### Example: exact match for one system setting
+
+Suppose you want this MQTT topic:
+
+`N/<portalId>/settings/0/Settings/SystemSetup/MaxChargeCurrent`
+
+to appear in Signal K as:
+
+`electrical.venus.maxChargeCurrent`
+
+Fill out the custom mapping like this:
+
+- `Venus Path`: `/Settings/SystemSetup/MaxChargeCurrent`
+- `Interpret Venus Path As Regex`: off
+- `D-Bus Sender Filter`: leave blank
+- `Signal K Path`: `electrical.${venusName}.maxChargeCurrent`
+- `Units`: `A`
+- `Conversion`: `None`
+
+### Example: match all VE.Bus devices with one rule
+
+Suppose you have topics like:
+
+- `N/<portalId>/vebus/276/Dc/0/MaxChargeCurrent`
+- `N/<portalId>/vebus/288/Dc/0/MaxChargeCurrent`
+
+and you want them to appear as:
+
+- `electrical.chargers.276.maxChargeCurrent`
+- `electrical.chargers.288.maxChargeCurrent`
+
+Fill out the custom mapping like this:
+
+- `Venus Path`: `^/Dc/0/MaxChargeCurrent$`
+- `Interpret Venus Path As Regex`: on
+- `D-Bus Sender Filter`: `com.victronenergy.vebus`
+- `D-Bus Sender Match Mode`: `Prefix`
+- `Signal K Path`: `electrical.chargers.${instanceName}.maxChargeCurrent`
+- `Units`: `A`
+- `Conversion`: `None`
+
+The sender filter is useful because `/Dc/0/...` style paths are common in Venus. Without a sender filter, you might match more than just VE.Bus devices.
+
+### Example: exact sender match
+
+If you want a mapping to apply only to one specific D-Bus sender, use an exact match.
+
+For example, for:
+
+`N/<portalId>/settings/0/Settings/SystemSetup/MaxChargeCurrent`
+
+you could fill out:
+
+- `Venus Path`: `/Settings/SystemSetup/MaxChargeCurrent`
+- `Interpret Venus Path As Regex`: off
+- `D-Bus Sender Filter`: `com.victronenergy.settings.0`
+- `D-Bus Sender Match Mode`: `Exact`
+- `Signal K Path`: `electrical.${venusName}.maxChargeCurrent`
+- `Units`: `A`
+
+### Notes
+
+- Use `Interpret Venus Path As Regex` only when you need it. Most mappings should be exact path matches.
+- Leave `D-Bus Sender Filter` blank when the Venus path is specific enough by itself.
+- Use `Prefix` sender matching when you want one rule to apply to a whole device family such as `com.victronenergy.vebus`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -241,13 +241,13 @@ module.exports = function (app: ServerAPI) {
                   default: false
                 },
                 dbusService: {
-                  title: 'Only Map Values From D-Bus Service',
+                  title: 'D-Bus Sender Filter',
                   type: 'string',
                   description:
-                    'Optional D-Bus service filter, for example com.victronenergy.vebus. Leave blank for no restriction.'
+                    'Optional D-Bus sender filter, for example com.victronenergy.vebus. Leave blank for no restriction.'
                 },
                 dbusServiceMatchMode: {
-                  title: 'D-Bus Service Match Mode',
+                  title: 'D-Bus Sender Match Mode',
                   type: 'string',
                   enum: ['prefix', 'exact'],
                   enumNames: ['Prefix', 'Exact'],

--- a/src/index.ts
+++ b/src/index.ts
@@ -240,13 +240,13 @@ module.exports = function (app: ServerAPI) {
                     'Enable for advanced matching such as ^/Dc/0/MaxChargeCurrent$',
                   default: false
                 },
-                dbusService: {
+                senderFilter: {
                   title: 'D-Bus Sender Filter',
                   type: 'string',
                   description:
                     'Optional D-Bus sender filter, for example com.victronenergy.vebus. Leave blank for no restriction.'
                 },
-                dbusServiceMatchMode: {
+                senderMatchMode: {
                   title: 'D-Bus Sender Match Mode',
                   type: 'string',
                   enum: ['prefix', 'exact'],

--- a/src/index.ts
+++ b/src/index.ts
@@ -219,6 +219,78 @@ module.exports = function (app: ServerAPI) {
               }
             }
           },
+          customMappings: {
+            title: 'Custom Mappings',
+            description:
+              'Read-only custom mappings from Venus MQTT/DBus paths to Signal K paths',
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                venusPath: {
+                  title: 'Venus Path',
+                  type: 'string',
+                  description:
+                    'Venus path to match, for example /Settings/SystemSetup/MaxChargeCurrent'
+                },
+                venusPathIsRegex: {
+                  title: 'Interpret Venus Path As Regex',
+                  type: 'boolean',
+                  description:
+                    'Enable for advanced matching such as ^/Dc/0/MaxChargeCurrent$',
+                  default: false
+                },
+                dbusService: {
+                  title: 'Only Map Values From D-Bus Service',
+                  type: 'string',
+                  description:
+                    'Optional D-Bus service filter, for example com.victronenergy.vebus'
+                },
+                dbusServiceMatchMode: {
+                  title: 'D-Bus Service Match Mode',
+                  type: 'string',
+                  enum: ['none', 'prefix', 'exact'],
+                  enumNames: ['None', 'Prefix', 'Exact'],
+                  default: 'none',
+                  description: 'How to interpret the optional D-Bus service filter'
+                },
+                signalkPath: {
+                  title: 'Signal K Path',
+                  type: 'string',
+                  description:
+                    'Target Signal K path template. Supported tokens: ${instanceName}, ${venusName}, ${senderName}'
+                },
+                units: {
+                  title: 'Units',
+                  type: 'string',
+                  description: 'Optional Signal K meta.units value'
+                },
+                conversion: {
+                  title: 'Conversion',
+                  type: 'string',
+                  enum: [
+                    'none',
+                    'celsiusToKelvin',
+                    'percentToRatio',
+                    'ahToCoulomb',
+                    'kWhToJoules',
+                    'degsToRad',
+                    'zeroOneToBoolean'
+                  ],
+                  enumNames: [
+                    'None',
+                    'Celsius to Kelvin',
+                    'Percent to Ratio',
+                    'Amp-hours to Coulomb',
+                    'kWh to Joules',
+                    'Degrees to Radians',
+                    '0/1 to Boolean'
+                  ],
+                  default: 'none'
+                }
+              }
+            }
+          },
           blacklist: {
             title: 'Block List',
             description: 'These paths will be ignored',

--- a/src/index.ts
+++ b/src/index.ts
@@ -249,10 +249,11 @@ module.exports = function (app: ServerAPI) {
                 dbusServiceMatchMode: {
                   title: 'D-Bus Service Match Mode',
                   type: 'string',
-                  enum: ['none', 'prefix', 'exact'],
-                  enumNames: ['None', 'Prefix', 'Exact'],
-                  default: 'none',
-                  description: 'How to interpret the optional D-Bus service filter'
+                  enum: ['prefix', 'exact'],
+                  enumNames: ['Prefix', 'Exact'],
+                  default: 'prefix',
+                  description:
+                    'How to interpret the optional D-Bus service filter. Leave D-Bus service blank for no restriction.'
                 },
                 signalkPath: {
                   title: 'Signal K Path',

--- a/src/index.ts
+++ b/src/index.ts
@@ -244,7 +244,7 @@ module.exports = function (app: ServerAPI) {
                   title: 'Only Map Values From D-Bus Service',
                   type: 'string',
                   description:
-                    'Optional D-Bus service filter, for example com.victronenergy.vebus'
+                    'Optional D-Bus service filter, for example com.victronenergy.vebus. Leave blank for no restriction.'
                 },
                 dbusServiceMatchMode: {
                   title: 'D-Bus Service Match Mode',
@@ -252,8 +252,7 @@ module.exports = function (app: ServerAPI) {
                   enum: ['prefix', 'exact'],
                   enumNames: ['Prefix', 'Exact'],
                   default: 'prefix',
-                  description:
-                    'How to interpret the optional D-Bus service filter. Leave D-Bus service blank for no restriction.'
+                  description: 'How to interpret the optional D-Bus service filter'
                 },
                 signalkPath: {
                   title: 'Signal K Path',

--- a/src/mappings.ts
+++ b/src/mappings.ts
@@ -78,8 +78,8 @@ type DbusServiceMatchMode = 'exact' | 'prefix'
 export type CustomMappingConfig = {
   venusPath: string
   venusPathIsRegex?: boolean
-  dbusService?: string
-  dbusServiceMatchMode?: DbusServiceMatchMode
+  senderFilter?: string
+  senderMatchMode?: DbusServiceMatchMode
   signalkPath: string
   units?: string
   conversion?: CustomConversion
@@ -1527,23 +1527,23 @@ const normalizeCustomMapping = (
     normalized.venusPath = mapping.venusPath
   }
 
-  const dbusServiceMatchMode = mapping.dbusServiceMatchMode || 'prefix'
+  const senderMatchMode = mapping.senderMatchMode || 'prefix'
 
-  if (mapping.dbusService && !['exact', 'prefix'].includes(dbusServiceMatchMode)) {
+  if (mapping.senderFilter && !['exact', 'prefix'].includes(senderMatchMode)) {
     app.error(
-      `customMappings[${index}] skipped: invalid dbusServiceMatchMode "${dbusServiceMatchMode}"`
+      `customMappings[${index}] skipped: invalid senderMatchMode "${senderMatchMode}"`
     )
     return
   }
 
-  if (mapping.dbusService && mapping.dbusService.length) {
-    if (dbusServiceMatchMode === 'exact') {
-      normalized.senderNameExact = mapping.dbusService
-    } else if (dbusServiceMatchMode === 'prefix') {
-      normalized.senderNamePrefix = mapping.dbusService
+  if (mapping.senderFilter && mapping.senderFilter.length) {
+    if (senderMatchMode === 'exact') {
+      normalized.senderNameExact = mapping.senderFilter
+    } else if (senderMatchMode === 'prefix') {
+      normalized.senderNamePrefix = mapping.senderFilter
     } else {
       app.error(
-        `customMappings[${index}] skipped: invalid dbusServiceMatchMode "${dbusServiceMatchMode}"`
+        `customMappings[${index}] skipped: invalid senderMatchMode "${senderMatchMode}"`
       )
       return
     }

--- a/src/mappings.ts
+++ b/src/mappings.ts
@@ -73,7 +73,7 @@ type CustomConversion =
   | 'degsToRad'
   | 'zeroOneToBoolean'
 
-type DbusServiceMatchMode = 'none' | 'exact' | 'prefix'
+type DbusServiceMatchMode = 'exact' | 'prefix'
 
 export type CustomMappingConfig = {
   venusPath: string
@@ -1527,9 +1527,9 @@ const normalizeCustomMapping = (
     normalized.venusPath = mapping.venusPath
   }
 
-  const dbusServiceMatchMode = mapping.dbusServiceMatchMode || 'none'
+  const dbusServiceMatchMode = mapping.dbusServiceMatchMode || 'prefix'
 
-  if (mapping.dbusService && !['none', 'exact', 'prefix'].includes(dbusServiceMatchMode)) {
+  if (mapping.dbusService && !['exact', 'prefix'].includes(dbusServiceMatchMode)) {
     app.error(
       `customMappings[${index}] skipped: invalid dbusServiceMatchMode "${dbusServiceMatchMode}"`
     )
@@ -1541,7 +1541,7 @@ const normalizeCustomMapping = (
       normalized.senderNameExact = mapping.dbusService
     } else if (dbusServiceMatchMode === 'prefix') {
       normalized.senderNamePrefix = mapping.dbusService
-    } else if (dbusServiceMatchMode !== 'none') {
+    } else {
       app.error(
         `customMappings[${index}] skipped: invalid dbusServiceMatchMode "${dbusServiceMatchMode}"`
       )

--- a/src/mappings.ts
+++ b/src/mappings.ts
@@ -73,13 +73,13 @@ type CustomConversion =
   | 'degsToRad'
   | 'zeroOneToBoolean'
 
-type DbusServiceMatchMode = 'exact' | 'prefix'
+type SenderMatchMode = 'exact' | 'prefix'
 
 export type CustomMappingConfig = {
   venusPath: string
   venusPathIsRegex?: boolean
   senderFilter?: string
-  senderMatchMode?: DbusServiceMatchMode
+  senderMatchMode?: SenderMatchMode
   signalkPath: string
   units?: string
   conversion?: CustomConversion

--- a/src/mappings.ts
+++ b/src/mappings.ts
@@ -64,12 +64,33 @@ export type VenusToSignalKRegExMapping = {
   mappings: VenusToSignalKMapping[]
 }
 
+type CustomConversion =
+  | 'none'
+  | 'celsiusToKelvin'
+  | 'percentToRatio'
+  | 'ahToCoulomb'
+  | 'kWhToJoules'
+  | 'degsToRad'
+  | 'zeroOneToBoolean'
+
+type DbusServiceMatchMode = 'none' | 'exact' | 'prefix'
+
+export type CustomMappingConfig = {
+  venusPath: string
+  venusPathIsRegex?: boolean
+  dbusService?: string
+  dbusServiceMatchMode?: DbusServiceMatchMode
+  signalkPath: string
+  units?: string
+  conversion?: CustomConversion
+}
+
 export const getMappings = (
   app: ServerAPI,
   options: any,
   state: any
 ): VenusToSignalKMappings => {
-  return {
+  const mappings: VenusToSignalKMappings = {
     '/CustomName': [
       {
         path: (m) => {
@@ -1313,6 +1334,19 @@ export const getMappings = (
     },
     */
   }
+
+  getCustomExactMappings(app, options, state).forEach(({ venusPath, mapping }) => {
+    const existing = mappings[venusPath]
+    if (existing === undefined) {
+      mappings[venusPath] = mapping
+    } else if (Array.isArray(existing)) {
+      existing.push(mapping)
+    } else {
+      mappings[venusPath] = [existing, mapping]
+    }
+  })
+
+  return mappings
 }
 
 export const getDIMappings = (
@@ -1368,10 +1402,11 @@ export const getDIMappings = (
 
 export const getRegExMappings = (
   app: any,
-  _options: any,
+  options: any,
   state: any
 ): VenusToSignalKRegExMapping[] => {
   return [
+    ...getCustomRegExMappings(app, options, state),
     {
       regex: /^\/SwitchableOutput\/([^/]+)\/State$/,
       mappings: getSwitchStateMapping(app, state)
@@ -1389,6 +1424,187 @@ export const getRegExMappings = (
       mappings: getSwitchSettingsMapping(app, state)
     }
   ]
+}
+
+const getCustomExactMappings = (
+  app: ServerAPI,
+  options: any,
+  state: any
+): Array<{ venusPath: string; mapping: VenusToSignalKMapping }> => {
+  const customMappings = normalizeCustomMappings(app, options, state)
+
+  return customMappings
+    .filter((mapping) => mapping.venusPath)
+    .map((mapping) => {
+      return {
+        venusPath: mapping.venusPath!,
+        mapping: buildCustomMapping(mapping)
+      }
+    })
+}
+
+const getCustomRegExMappings = (
+  app: ServerAPI,
+  options: any,
+  state: any
+): VenusToSignalKRegExMapping[] => {
+  return normalizeCustomMappings(app, options, state)
+    .filter((mapping) => mapping.venusPathRegex)
+    .map((mapping) => {
+      return {
+        regex: mapping.venusPathRegex!,
+        mappings: [buildCustomMapping(mapping)]
+      }
+    })
+}
+
+type NormalizedCustomMapping = {
+  venusPath?: string
+  venusPathRegex?: RegExp
+  senderNameExact?: string
+  senderNamePrefix?: string
+  signalkPath: string
+  units?: string
+  conversion?: MappingConversion
+}
+
+const normalizeCustomMappings = (
+  app: ServerAPI,
+  options: any,
+  _state: any
+): NormalizedCustomMapping[] => {
+  const customMappings = options?.customMappings
+
+  if (!Array.isArray(customMappings)) {
+    return []
+  }
+
+  return customMappings
+    .map((mapping: CustomMappingConfig, index: number) =>
+      normalizeCustomMapping(app, mapping, index)
+    )
+    .filter((mapping): mapping is NormalizedCustomMapping => mapping !== undefined)
+}
+
+const normalizeCustomMapping = (
+  app: ServerAPI,
+  mapping: CustomMappingConfig,
+  index: number
+): NormalizedCustomMapping | undefined => {
+  if (
+    !mapping ||
+    typeof mapping.signalkPath !== 'string' ||
+    !mapping.signalkPath.length
+  ) {
+    app.error(
+      `customMappings[${index}] skipped: signalkPath is required and must be a non-empty string`
+    )
+    return
+  }
+
+  if (typeof mapping.venusPath !== 'string' || !mapping.venusPath.length) {
+    app.error(
+      `customMappings[${index}] skipped: venusPath is required and must be a non-empty string`
+    )
+    return
+  }
+
+  const normalized: NormalizedCustomMapping = {
+    signalkPath: mapping.signalkPath,
+    units: mapping.units
+  }
+
+  if (mapping.venusPathIsRegex) {
+    try {
+      normalized.venusPathRegex = new RegExp(mapping.venusPath)
+    } catch (err: any) {
+      app.error(
+        `customMappings[${index}] skipped: invalid venusPath regex: ${err.message}`
+      )
+      return
+    }
+  } else {
+    normalized.venusPath = mapping.venusPath
+  }
+
+  const dbusServiceMatchMode = mapping.dbusServiceMatchMode || 'none'
+
+  if (mapping.dbusService && !['none', 'exact', 'prefix'].includes(dbusServiceMatchMode)) {
+    app.error(
+      `customMappings[${index}] skipped: invalid dbusServiceMatchMode "${dbusServiceMatchMode}"`
+    )
+    return
+  }
+
+  if (mapping.dbusService && mapping.dbusService.length) {
+    if (dbusServiceMatchMode === 'exact') {
+      normalized.senderNameExact = mapping.dbusService
+    } else if (dbusServiceMatchMode === 'prefix') {
+      normalized.senderNamePrefix = mapping.dbusService
+    } else if (dbusServiceMatchMode !== 'none') {
+      app.error(
+        `customMappings[${index}] skipped: invalid dbusServiceMatchMode "${dbusServiceMatchMode}"`
+      )
+      return
+    }
+  }
+
+  const conversion = getCustomConversion(mapping.conversion)
+  if (conversion === null) {
+    app.error(
+      `customMappings[${index}] skipped: unsupported conversion "${mapping.conversion}"`
+    )
+    return
+  }
+  normalized.conversion = conversion || undefined
+
+  return normalized
+}
+
+const buildCustomMapping = (
+  mapping: NormalizedCustomMapping
+): VenusToSignalKMapping => {
+  return {
+    path: (m: Message) => {
+      if (mapping.senderNameExact && m.senderName !== mapping.senderNameExact) {
+        return undefined
+      }
+
+      if (mapping.senderNamePrefix && !m.senderName.startsWith(mapping.senderNamePrefix)) {
+        return undefined
+      }
+
+      return renderCustomPath(mapping.signalkPath, m)
+    },
+    units: mapping.units,
+    conversion: mapping.conversion
+  }
+}
+
+const renderCustomPath = (template: string, m: Message) => {
+  return template.replace(/\$\{(instanceName|venusName|senderName)\}/g, (_match, key) => {
+    const value = m[key as 'instanceName' | 'venusName' | 'senderName']
+    return value === undefined || value === null ? '' : String(value)
+  })
+}
+
+const getCustomConversion = (
+  conversion: CustomConversion | undefined
+): MappingConversion | null | undefined => {
+  if (conversion === undefined || conversion === 'none') {
+    return undefined
+  }
+
+  const conversions: Record<Exclude<CustomConversion, 'none'>, MappingConversion> = {
+    celsiusToKelvin,
+    percentToRatio,
+    ahToCoulomb,
+    kWhToJoules,
+    degsToRad,
+    zeroOneToBoolean: (msg: Message) => msg.value === 1
+  }
+
+  return conversions[conversion] || null
 }
 
 const getSwitchChannelIndex = (m: Message): string => {

--- a/test/venusToDelta.ts
+++ b/test/venusToDelta.ts
@@ -197,8 +197,8 @@ describe('customMappings', () => {
           {
             venusPath: '^/Dc/0/MaxChargeCurrent$',
             venusPathIsRegex: true,
-            dbusService: 'com.victronenergy.vebus',
-            dbusServiceMatchMode: 'prefix',
+            senderFilter: 'com.victronenergy.vebus',
+            senderMatchMode: 'prefix',
             signalkPath: 'electrical.chargers.${instanceName}.maxChargeCurrent',
             units: 'A'
           }
@@ -291,8 +291,8 @@ describe('customMappings', () => {
           {
             venusPath: '^/Dc/0/MaxChargeCurrent$',
             venusPathIsRegex: true,
-            dbusService: 'com.victronenergy.vebus',
-            dbusServiceMatchMode: 'prefix',
+            senderFilter: 'com.victronenergy.vebus',
+            senderMatchMode: 'prefix',
             signalkPath: 'electrical.chargers.${instanceName}.maxChargeCurrent',
             units: 'A'
           }

--- a/test/venusToDelta.ts
+++ b/test/venusToDelta.ts
@@ -130,3 +130,186 @@ files.forEach((item) => {
     })
   })
 })
+
+describe('customMappings', () => {
+  it('maps an exact Venus path to a system-level Signal K path', () => {
+    const vsk = new VenusToSignalK(
+      {
+        getSelfPath: (_path: string) => undefined
+      } as ServerAPI,
+      {
+        customMappings: [
+          {
+            venusPath: '/Settings/SystemSetup/MaxChargeCurrent',
+            signalkPath: 'electrical.${venusName}.maxChargeCurrent',
+            units: 'A'
+          }
+        ]
+      },
+      {},
+      () => undefined
+    )
+
+    const deltas = vsk.toDelta({
+      path: '/Settings/SystemSetup/MaxChargeCurrent',
+      instanceName: '0',
+      senderName: 'com.victronenergy.settings.0',
+      venusName: 'venus',
+      value: 0
+    })
+
+    expect(deltas).to.deep.equal([
+      {
+        updates: [
+          {
+            meta: [
+              {
+                path: 'electrical.venus.maxChargeCurrent',
+                value: { units: 'A' }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        updates: [
+          {
+            $source: 'venus.com.victronenergy.settings.0',
+            values: [
+              {
+                path: 'electrical.venus.maxChargeCurrent',
+                value: 0
+              }
+            ]
+          }
+        ]
+      }
+    ])
+  })
+
+  it('maps a regex Venus path to wildcard VE.Bus charger paths', () => {
+    const vsk = new VenusToSignalK(
+      {
+        getSelfPath: (_path: string) => undefined
+      } as ServerAPI,
+      {
+        customMappings: [
+          {
+            venusPath: '^/Dc/0/MaxChargeCurrent$',
+            venusPathIsRegex: true,
+            dbusService: 'com.victronenergy.vebus',
+            dbusServiceMatchMode: 'prefix',
+            signalkPath: 'electrical.chargers.${instanceName}.maxChargeCurrent',
+            units: 'A'
+          }
+        ]
+      },
+      {},
+      () => undefined
+    )
+
+    const first = vsk.toDelta({
+      path: '/Dc/0/MaxChargeCurrent',
+      instanceName: '276',
+      senderName: 'com.victronenergy.vebus.276',
+      venusName: 'venus',
+      value: 240
+    })
+
+    const second = vsk.toDelta({
+      path: '/Dc/0/MaxChargeCurrent',
+      instanceName: '288',
+      senderName: 'com.victronenergy.vebus.288',
+      venusName: 'venus',
+      value: 240
+    })
+
+    expect(first).to.deep.equal([
+      {
+        updates: [
+          {
+            meta: [
+              {
+                path: 'electrical.chargers.276.maxChargeCurrent',
+                value: { units: 'A' }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        updates: [
+          {
+            $source: 'venus.com.victronenergy.vebus.276',
+            values: [
+              {
+                path: 'electrical.chargers.276.maxChargeCurrent',
+                value: 240
+              }
+            ]
+          }
+        ]
+      }
+    ])
+
+    expect(second).to.deep.equal([
+      {
+        updates: [
+          {
+            meta: [
+              {
+                path: 'electrical.chargers.288.maxChargeCurrent',
+                value: { units: 'A' }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        updates: [
+          {
+            $source: 'venus.com.victronenergy.vebus.288',
+            values: [
+              {
+                path: 'electrical.chargers.288.maxChargeCurrent',
+                value: 240
+              }
+            ]
+          }
+        ]
+      }
+    ])
+  })
+
+  it('respects sender filters for custom mappings', () => {
+    const vsk = new VenusToSignalK(
+      {
+        getSelfPath: (_path: string) => undefined
+      } as ServerAPI,
+      {
+        customMappings: [
+          {
+            venusPath: '^/Dc/0/MaxChargeCurrent$',
+            venusPathIsRegex: true,
+            dbusService: 'com.victronenergy.vebus',
+            dbusServiceMatchMode: 'prefix',
+            signalkPath: 'electrical.chargers.${instanceName}.maxChargeCurrent',
+            units: 'A'
+          }
+        ]
+      },
+      {},
+      () => undefined
+    )
+
+    const deltas = vsk.toDelta({
+      path: '/Dc/0/MaxChargeCurrent',
+      instanceName: '512',
+      senderName: 'com.victronenergy.battery.512',
+      venusName: 'venus',
+      value: 99
+    })
+
+    expect(deltas).to.deep.equal([])
+  })
+})


### PR DESCRIPTION
## Summary

- Add a `customMappings` plugin option for mapping selected Venus paths to Signal K paths without changing plugin source.
- Support exact or regex Venus path matching, optional DBus service/sender matching, and template variables such as `${venusName}`, `${instanceName}`, and `${senderName}`.
- Document common examples, including system max charge current and per-charger max charge current mappings.
- Add test coverage for custom mapping sender filters.

## Testing

- `npm run build`
- `npm test -- --grep \"custom mapping\"`
