### PR TITLE
feat: map Victron pulsemeter /Count and /Aggregate to electrical.pulsemeter

### DIFF
--- a/src/mappings.ts
+++ b/src/mappings.ts
@@ -92,6 +92,21 @@ export const getMappings = (
         }
       }
     ],
+    '/Count': {
+      path: (m) => {
+        return m.senderName.startsWith('com.victronenergy.pulsemeter')
+          ? makePath(m, `${m.instanceName}.count`)
+          : undefined
+      }
+    },
+    '/Aggregate': {
+      path: (m) => {
+        return m.senderName.startsWith('com.victronenergy.pulsemeter')
+          ? makePath(m, `${m.instanceName}.aggregate`)
+          : undefined
+      },
+      units: 'm3'
+    },
     '/Settings/SystemSetup/SystemName': {
       path: (m) => {
         return makePath(m, `name`)

--- a/test/dbus-test.log
+++ b/test/dbus-test.log
@@ -2304,3 +2304,5 @@
 {"message":{"path":"/Settings/Vrmlogger/Http/Proxy","senderName":"com.victronenergy.settings","value":"","venusName":"venus"},"deltas":[]}
 {"message":{"path":"/Settings/Vrmlogger/Http/ProxyPort","senderName":"com.victronenergy.settings","value":"","venusName":"venus"},"deltas":[]}
 {"message":{"path":"/Settings/Watchdog/VrmTimeout","senderName":"com.victronenergy.settings","value":0,"venusName":"venus"},"deltas":[]}
+{"message":{"path":"/Count","senderName":"com.victronenergy.pulsemeter.input_1","value":127,"instanceName":1,"venusName":"venus"},"deltas":[{"updates":[{"$source":"venus.com.victronenergy.pulsemeter.input_1","values":[{"path":"electrical.pulsemeter.1.count","value":127}]}]}]}
+{"message":{"path":"/Aggregate","senderName":"com.victronenergy.pulsemeter.input_1","value":0.127,"instanceName":1,"venusName":"venus"},"deltas":[{"updates":[{"meta":[{"path":"electrical.pulsemeter.1.aggregate","value":{"units":"m3"}}]}]},{"updates":[{"$source":"venus.com.victronenergy.pulsemeter.input_1","values":[{"path":"electrical.pulsemeter.1.aggregate","value":0.127}]}]}]}


### PR DESCRIPTION
## Summary

Venus exposes pulse-meter inputs as their own dbus service, `com.victronenergy.pulsemeter.input_N`, which the plugin never mapped. This adds two entries in `src/mappings.ts`:

- `electrical.pulsemeter.{id}.count` - pulse count
- `electrical.pulsemeter.{id}.aggregate` - volume in m³ (already computed by Venus, so published as `units: m3` with no conversion)

Both are guarded to `com.victronenergy.pulsemeter` so a stray `/Count` or `/Aggregate` from another service can't land on the wrong path.

## Tested

- `npm run build` and lint clean.
- Added `/Count` and `/Aggregate` fixtures to `test/dbus-test.log`. `npm test` passes, no regressions.

Closes #199